### PR TITLE
WIP refactor: initialization, removing looped use, other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 * better document with comments; "pattern" vs "screen" as img1 vs img2
   * and note that output keypoint matches are scaled down to 512x512 space, and img2 by 1.25 smaller than that
-* assess use of `requestAnimationFrame` for repeated runs - is it necessary?
 * continue to modularize files in /src/, reducing dependence on shared state
 * optimize if necessary: reduce use of jsfeat resample methods
 
@@ -14,6 +13,9 @@ Short-term:
 
 * allow initialization independent of `window.onload` (done, needs docs)
 * refactor to not run continuously
+  * assess use of `requestAnimationFrame` for repeated runs - is it necessary?
+* refactor `resolve(X)` and `resolve(Y)` on construction to enable use of video sources? (i.e. non-string values of X, Y: mediaStream instead)
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
-# [`matcher-core`](/): ORB-focused pattern-miner for PublicLab
+# [`matcher-core`](/): ORB-focused image pattern-matcher for Public Lab
 
 ![LICENSE](https://img.shields.io/badge/license-GNU--General--Public--License--v3.0-green.svg)
+
+## TODO
+
+* better document with comments; "pattern" vs "screen" as img1 vs img2
+  * and note that output keypoint matches are scaled down to 512x512 space, and img2 by 1.25 smaller than that
+* assess use of `requestAnimationFrame` for repeated runs - is it necessary?
+* continue to modularize files in /src/, reducing dependence on shared state
+* optimize if necessary: reduce use of jsfeat resample methods
+
+Short-term:
+
+* allow initialization independent of `window.onload` (done, needs docs)
+* refactor to not run continuously
 
 ## Installation
 
 Simply do, `npm i matcher-core`.
 
-Also, when using ARM based devices, its highly recommended to additionally install the packages: `libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libgtk-3-0 libxinerama1 libcairo-gobject2` that can be easily installed using `npm run fetch`.
+Also, if running in a node environment, when using ARM based devices, its highly recommended to additionally install the packages: `libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libgtk-3-0 libxinerama1 libcairo-gobject2` that can be easily installed using `npm run fetch`.
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Short-term:
 * refactor to not run continuously
   * assess use of `requestAnimationFrame` for repeated runs - is it necessary?
 * refactor `resolve(X)` and `resolve(Y)` on construction to enable use of video sources? (i.e. non-string values of X, Y: mediaStream instead)
-
+X allow passing image objects instead of src to constructor
 
 ## Installation
 

--- a/assets/utils/orb.detectKeypoints.js
+++ b/assets/utils/orb.detectKeypoints.js
@@ -1,7 +1,10 @@
 const jsfeat = require('../js/jsfeat.min.js');
 const {icAngle} = require('./orb.icAngle.js');
 
+// expects pre-initialized corners array of:
+// `new jsfeat.keypoint_t(0, 0, 0, 0, -1);` empty corners
 // https://inspirit.github.io/jsfeat/sample_orb.html
+// https://inspirit.github.io/jsfeat/#features2d
 function detectKeypoints(img, corners, maxAllowed) {
   // detect features
   let count = jsfeat.yape06.detect(img, corners, 17);

--- a/src/orb.core.js
+++ b/src/orb.core.js
@@ -29,6 +29,7 @@ const orbify = function(X, Y, cb, args = {}) {
     matchesArray = [],
     cornersArray = [];
 
+  // in-progress work to accommodate 
   if (typeof X === "string") primaryImage.src = resolve(X);
   if (typeof Y === "string") secImage.src = resolve(Y);
   const img1Width = primaryImage.width || primaryImage.videoWidth || 0;
@@ -243,7 +244,7 @@ console.log('width',img1Width);
       }
 
       // repeat this method as fast as the browser can run it
-      window.requestAnimationFrame(findPoints);
+      if (args.loop) window.requestAnimationFrame(findPoints);
 
       const primaryImageData = ctx.getImageData(0, 0, self.args.dimensions[0], self.args.dimensions[1]);
 
@@ -282,7 +283,7 @@ console.log('width',img1Width);
         if (await matchesArray.length) {
           return;
         }
-        requestAnimationFrame(findMatchedPoints);
+        if (args.loop) requestAnimationFrame(findMatchedPoints);
         if (patternPreview) {
           numMatches = await matchPattern(
               matches,

--- a/src/orb.core.js
+++ b/src/orb.core.js
@@ -21,19 +21,22 @@ const orbify = function(X, Y, cb, args = {}) {
   this.args = args;
   self = this;
   const canvas = document.createElement('CANVAS'),
-    c = document.createElement('CANVAS'),
-    primaryImage = new Image(),
+    c = document.createElement('CANVAS');
+
+  if (X instanceof Image) var primaryImage = X;
+  else {
+    primaryImage = new Image();
+    primaryImage.src = X;
+  }
+  if (Y instanceof Image) var secImage = Y;
+  else {
     secImage = new Image();
+    secImage.src = Y;
+  }
 
   let options,
     matchesArray = [],
     cornersArray = [];
-
-  // in-progress work to accommodate 
-  if (typeof X === "string") primaryImage.src = resolve(X);
-  if (typeof Y === "string") secImage.src = resolve(Y);
-  const img1Width = primaryImage.width || primaryImage.videoWidth || 0;
-  const img1Height = primaryImage.height || primaryImage.videoHeight || 0;
 
   canvas.setAttribute('id', 'canvas');
   canvas.setAttribute('width', self.args.dimensions[0]);
@@ -42,8 +45,8 @@ const orbify = function(X, Y, cb, args = {}) {
   c.setAttribute('style', 'border:1px solid #d3d3d3');
 
   function initialize() {
-    c.width = img1Width;
-    c.height = img1Height;
+    c.width = primaryImage.width;
+    c.height = primaryImage.height;
     c.style.display = 'none';
 
     const ctxx = c.getContext('2d');
@@ -51,12 +54,11 @@ const orbify = function(X, Y, cb, args = {}) {
         primaryImage,
         0,
         0,
-        img1Width,
-        img1Height
+        primaryImage.width,
+        primaryImage.height
     );
 
     options.train_pattern();
-    console.log('trained pattern');
   };
 
   (function core() {
@@ -108,7 +110,6 @@ const orbify = function(X, Y, cb, args = {}) {
       this.matchThreshold = params.matchThreshold || 49;
 
       this.train_pattern = function() {
-console.log('width',img1Width);
         const maxPatternSize = 512,
           maxPerLevel = 300,
           scInc = Math.sqrt(2.0),
@@ -116,17 +117,17 @@ console.log('width',img1Width);
           imgData = ctxx.getImageData(
               0,
               0,
-              img1Width,
-              img1Height
+              primaryImage.width,
+              primaryImage.height
           ),
           imgg = new jsfeat.matrix_t(
-              img1Width,
-              img1Height,
+              primaryImage.width,
+              primaryImage.height,
               jsfeat.U8_t | jsfeat.C1_t
           ),
           sc0 = Math.min(
-              maxPatternSize / img1Width,
-              maxPatternSize / img1Height
+              maxPatternSize / primaryImage.width,
+              maxPatternSize / primaryImage.height
           ),
           lev0Img = new jsfeat.matrix_t(
               imgU8.cols,
@@ -142,8 +143,8 @@ console.log('width',img1Width);
         let lev = 0,
           i = 0,
           sc = 1.0,
-          newWidth = (img1Width * sc0) | 0,
-          newHeight = (img1Height * sc0) | 0,
+          newWidth = (primaryImage.width * sc0) | 0,
+          newHeight = (primaryImage.height * sc0) | 0,
           levCorners,
           levDescriptors,
           cornersNum = 0;
@@ -175,8 +176,8 @@ console.log('width',img1Width);
 
         jsfeat.imgproc.grayscale(
             imgData.data,
-            img1Width,
-            img1Height,
+            primaryImage.width,
+            primaryImage.height,
             imgg
         );
         jsfeat.imgproc.resample(imgg, lev0Img, newWidth, newHeight);
@@ -184,7 +185,7 @@ console.log('width',img1Width);
         jsfeat.imgproc.gaussian_blur(lev0Img, levImg, options.blur_size | 0);
         cornersNum = detectKeypoints(levImg, levCorners, maxPerLevel);
         jsfeat.orb.describe(levImg, levCorners, cornersNum, levDescriptors);
-        /// console.log("train " + levImg.cols + "x" + levImg.rows + " points: " + cornersNum, levCorners);
+        // console.log("train " + levImg.cols + "x" + levImg.rows + " points: " + cornersNum, levCorners);
 
         sc /= scInc;
 
@@ -201,7 +202,6 @@ console.log('width',img1Width);
           cornersNum = detectKeypoints(levImg, levCorners, maxPerLevel);
           jsfeat.orb.describe(levImg, levCorners, cornersNum, levDescriptors);
           for (i = 0; i < cornersNum; ++i) {
-//console.log('scaling', levCorners[i].x, levCorners[i].x *= 1 / sc);
             levCorners[i].x *= 1 / sc;
             levCorners[i].y *= 1 / sc;
           }
@@ -238,13 +238,12 @@ console.log('width',img1Width);
     }
 
     async function findPoints() {
-      console.log('find points');
       if (await cornersArray.length) {
         return true;
       }
 
       // repeat this method as fast as the browser can run it
-      if (args.loop) window.requestAnimationFrame(findPoints);
+      if (true || args.loop) window.requestAnimationFrame(findPoints);
 
       const primaryImageData = ctx.getImageData(0, 0, self.args.dimensions[0], self.args.dimensions[1]);
 
@@ -276,14 +275,13 @@ console.log('width',img1Width);
     }
 
     async function findMatchedPoints() {
-      console.log('find matched points');
       let numMatches = 0,
         goodMatches = 0;
       if (findPoints()) {
         if (await matchesArray.length) {
           return;
         }
-        if (args.loop) requestAnimationFrame(findMatchedPoints);
+        if (true || args.loop) requestAnimationFrame(findMatchedPoints);
         if (patternPreview) {
           numMatches = await matchPattern(
               matches,


### PR DESCRIPTION
## TODO

* better document with comments; "pattern" vs "screen" as img1 vs img2
  * and note that output keypoint matches are scaled down to 512x512 space, and img2 by 1.25 smaller than that
* continue to modularize files in /src/, reducing dependence on shared state
* optimize if necessary: reduce use of jsfeat resample methods

Short-term:

* allow initialization independent of `window.onload` (done, needs docs)
* refactor to not run continuously
  * assess use of `requestAnimationFrame` for repeated runs - is it necessary?
* refactor `resolve(X)` and `resolve(Y)` on construction to enable use of video sources? (i.e. non-string values of X, Y: mediaStream instead)


****

One issue here is that we would like to accept video elements instead of image elements, i.e. `mediaStream` instead of `Image`. But that may require substantial refactoring of the library. I think we'll put this off for a while until we address other issues, and in the meantime, convert video image data to an `Image` instance using an intermediary canvas (inefficient but basic).